### PR TITLE
add exit/quit/q command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -184,6 +184,13 @@ func main() {
 				}
 				return nil
 			},
+		}, {
+			Name:    "exit",
+			Aliases: []string{"quit", "q"},
+			Hidden:  true,
+			Action: func(c *cli.Context) error {
+				return fmt.Errorf("exit")
+			},
 		},
 	}
 	for _, p := range protocol.APIlist {


### PR DESCRIPTION
> buildはできてヘルプ画面ぐらいまでは確認しましたが、p2pubapiをオプション無しで
起動、コマンドプロンプトがでて、そのままexitで抜けるとターミナル制御がおかしく
なるようです（resetすれば大丈夫なのですがちょっと気持ち悪い）。

使ってるcmdreplライブラリの問題もあったが、No help topic..でexitしないように修正。
これだとexitやquitと打っても終了しなくなるため、exit/quit/qコマンドも追加。