### PR TITLE
FW+LBのフィルタリングルールに対応

### DIFF
--- a/protocol/FwLbFilterGet.go
+++ b/protocol/FwLbFilterGet.go
@@ -1,0 +1,57 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbGet FW+LB情報取得 (同期)
+//  http://manual.iij.jp/p2/pubapi/59940904.html
+type FwLbFilterGet struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	IflServiceCode string `json:"-"` // FW+LB 専有タイプのサービスコード(ifl########)
+	IpVersion      string `json:"-"` // IPv4ルールかIPv6ルール（V4, V6）
+	Direction      string `json:"-"` // 入力方向（ExternalからInternalへ）のルールか出力方向のルールか。IPv6は"in"のみ指定可能（in, out）
+}
+
+// URI /:GisServiceCode/fw-lbs/:IflServiceCode/filters/:IpVersion/:Direction.json
+func (t FwLbFilterGet) URI() string {
+	return "/{{.GisServiceCode}}/fw-lbs/{{.IflServiceCode}}/filters/{{.IpVersion}}/{{.Direction}}.json"
+}
+
+// APIName FwLbFilterGet
+func (t FwLbFilterGet) APIName() string {
+	return "FwLbFilterGet"
+}
+
+// Method GET
+func (t FwLbFilterGet) Method() string {
+	return "GET"
+}
+
+// http://manual.iij.jp/p2/pubapi/73641921.html
+func (t FwLbFilterGet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/73641921.html"
+}
+
+// JPName フィルタリングルール情報取得
+func (t FwLbFilterGet) JPName() string {
+	return "フィルタリングルール情報取得"
+}
+func init() {
+	APIlist = append(APIlist, FwLbFilterGet{})
+	TypeMap["FwLbFilterGet"] = reflect.TypeOf(FwLbFilterGet{})
+}
+
+// FwLbFilterGetResponse フィルタリングルール情報取得のレスポンス
+type FwLbFilterGetResponse struct {
+	*CommonResponse
+	FilterRuleList []struct {
+		FilterId           string `json:",omitempty"`
+		SourceNetwork      string `json:",omitempty"`
+		DestinationNetwork string `json:",omitempty"`
+		DestinationPort    string `json:",omitempty"`
+		Protocol           string `json:",omitempty"`
+		Action             string `json:",omitempty"`
+		Label              string `json:",omitempty"`
+	} `json:",omitempty"`
+}

--- a/protocol/FwLbFilterSet.go
+++ b/protocol/FwLbFilterSet.go
@@ -1,0 +1,80 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+type FilterRule struct {
+	SourceNetwork      string `json:",omitempty"`
+	DestinationNetwork string `json:",omitempty"`
+	DestinationPort    string `json:",omitempty"`
+	Protocol           string `json:",omitempty"`
+	Action             string `json:",omitempty"`
+	Label              string `json:",omitempty"`
+}
+
+// FwLbFilterSet フィルタリングルール一括設定 (同期)
+//  http://manual.iij.jp/p2/pubapi/73641928.html
+type FwLbFilterSet struct {
+	GisServiceCode string       `json:"-"` // P2契約のサービスコード(gis########)
+	IflServiceCode string       `json:"-"` // FW+LB 専有タイプのサービスコード(ifl########)
+	IpVersion      string       `json:"-"` // IPv4ルールかIPv6ルール（V4, V6）
+	Direction      string       `json:"-"` // 入力方向（ExternalからInternalへ）のルールか出力方向のルールか。IPv6は"in"のみ指定可能（in, out）
+	FilterRuleList []FilterRule `json:",omitempty"`
+}
+
+// URI /:GisServiceCode/fw-lbs/:IflServiceCode/filters/:IpVersion/:Direction.json
+func (t FwLbFilterSet) URI() string {
+	return "/{{.GisServiceCode}}/fw-lbs/{{.IflServiceCode}}/filters/{{.IpVersion}}/{{.Direction}}.json"
+}
+
+// APIName FwLbFilterSet
+func (t FwLbFilterSet) APIName() string {
+	return "FwLbFilterSet"
+}
+
+// Method GET
+func (t FwLbFilterSet) Method() string {
+	return "PUT"
+}
+
+// http://manual.iij.jp/p2/pubapi/73641928.html
+func (t FwLbFilterSet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/73641928.html"
+}
+
+// JPName フィルタリングルール一括設定
+func (t FwLbFilterSet) JPName() string {
+	return "フィルタリングルール一括設定"
+}
+func init() {
+	APIlist = append(APIlist, FwLbFilterSet{})
+	TypeMap["FwLbFilterSet"] = reflect.TypeOf(FwLbFilterSet{})
+}
+
+// FwLbFilterSetResponse フィルタリングルール一括設定のレスポンス
+type FwLbFilterSetResponse struct {
+	*CommonResponse
+	Current struct {
+		FilterList []struct {
+			FilterId           string `json:",omitempty"`
+			SourceNetwork      string `json:",omitempty"`
+			DestinationNetwork string `json:",omitempty"`
+			DestinationPort    string `json:",omitempty"`
+			Protocol           string `json:",omitempty"`
+			Action             string `json:",omitempty"`
+			Label              string `json:",omitempty"`
+		} `json:",omitempty"`
+	}
+	Previous struct {
+		FilterList []struct {
+			FilterId           string `json:",omitempty"`
+			SourceNetwork      string `json:",omitempty"`
+			DestinationNetwork string `json:",omitempty"`
+			DestinationPort    string `json:",omitempty"`
+			Protocol           string `json:",omitempty"`
+			Action             string `json:",omitempty"`
+			Label              string `json:",omitempty"`
+		} `json:",omitempty"`
+	}
+}

--- a/protocol/FwLbGet.go
+++ b/protocol/FwLbGet.go
@@ -45,18 +45,21 @@ type FwLbGetResponse struct {
 	*CommonResponse
 	ResourceStatus string `json:",omitempty"` // FW+LB 専有タイプステータス
 	ServiceCode    string `json:",omitempty"` // FW+LB 専有タイプのサービスコード(ifl########)
-	TrafficIpList  []struct {
-		IPv4 struct {
-			TrafficIpName    string `json:",omitempty"` // トラフィックIP名(文字列)
-			TrafficIpAddress string `json:",omitempty"` // トラフィックIPv4アドレス(IPv4アドレス)
-			DomainName       string `json:",omitempty"` // 逆引きドメイン名。ネットワーク種別がGlobalに限る(文字列)
+	Lb             struct {
+		AdministrationServerAllowNetworkList []string `json:",omitempty"`
+		TrafficIpList                        []struct {
+			IPv4 struct {
+				TrafficIpName    string `json:",omitempty"` // トラフィックIP名(文字列)
+				TrafficIpAddress string `json:",omitempty"` // トラフィックIPv4アドレス(IPv4アドレス)
+				DomainName       string `json:",omitempty"` // 逆引きドメイン名。ネットワーク種別がGlobalに限る(文字列)
+			} `json:",omitempty"`
+			IPv6 struct {
+				TrafficIpName    string `json:",omitempty"` // トラフィックIP名(文字列)
+				TrafficIpAddress string `json:",omitempty"` // トラフィックIPv6アドレス(IPv6アドレス)
+				DomainName       string `json:",omitempty"` // 逆引きドメイン名。ネットワーク種別がGlobalに限る(文字列)
+			} `json:",omitempty"`
 		} `json:",omitempty"`
-		IPv6 struct {
-			TrafficIpName    string `json:",omitempty"` // トラフィックIP名(文字列)
-			TrafficIpAddress string `json:",omitempty"` // トラフィックIPv6アドレス(IPv6アドレス)
-			DomainName       string `json:",omitempty"` // 逆引きドメイン名。ネットワーク種別がGlobalに限る(文字列)
-		} `json:",omitempty"`
-	} `json:",omitempty"`
+	}
 	Internal struct {
 		NetworkType      string `json:",omitempty"` // ネットワーク種別
 		TrafficIpAddress string `json:",omitempty"` // トラフィックIPアドレス(IPアドレス)

--- a/protocol/LBControlPanelACLGet.go
+++ b/protocol/LBControlPanelACLGet.go
@@ -43,6 +43,5 @@ func init() {
 // LBControlPanelACLGetResponse LB管理画面アクセス制限情報取得のレスポンス
 type LBControlPanelACLGetResponse struct {
 	*CommonResponse
-	AdministrationServerAllowNetworkList []struct {
-	}
+	AdministrationServerAllowNetworkList []string `json:",omitempty"`
 }

--- a/protocol/LBControlPanelACLSet.go
+++ b/protocol/LBControlPanelACLSet.go
@@ -7,10 +7,9 @@ import (
 // LBControlPanelACLSet LB管理画面アクセス制限設定 (同期)
 //  http://manual.iij.jp/p2/pubapi/59941002.html
 type LBControlPanelACLSet struct {
-	GisServiceCode                       string `json:"-"` // P2契約のサービスコード(gis########)
-	IflServiceCode                       string `json:"-"` // FW+LB 専有タイプのサービスコード(ifl########)
-	AdministrationServerAllowNetworkList []struct {
-	}
+	GisServiceCode                       string   `json:"-"` // P2契約のサービスコード(gis########)
+	IflServiceCode                       string   `json:"-"` // FW+LB 専有タイプのサービスコード(ifl########)
+	AdministrationServerAllowNetworkList []string `json:",omitempty"`
 }
 
 // URI /{{.GisServiceCode}}/fw-lbs/{{.IflServiceCode}}/lb/adminserver/allows.json
@@ -45,4 +44,10 @@ func init() {
 // LBControlPanelACLSetResponse LB管理画面アクセス制限設定のレスポンス
 type LBControlPanelACLSetResponse struct {
 	*CommonResponse
+	Current struct {
+		AdministrationServerAllowNetworkList []string `json:",omitempty"`
+	}
+	Previous struct {
+		AdministrationServerAllowNetworkList []string `json:",omitempty"`
+	}
 }


### PR DESCRIPTION
FW+LBにフィルタリングルールを設定するAPIがあるのですが、未対応のようでしたので追加しました。手作業で作ってしまったので、もしお作法が違うということでしたら教えていただけると助かります。

http://manual.iij.jp/p2/pubapi/73641921.html
http://manual.iij.jp/p2/pubapi/73641928.html

それから、一部のAPIでリクエストおよびレスポンスのデータ構造が実際に一致していなかったので修正してあります。こちらもドキュメントを修正して自動生成の方がよければ、コメントをください。

以上の修正はterraformのp2pub providerにFW+LB対応のコードを追加した際の副産物ですので、動作確認はそちらでしてあります。
