### PR TITLE
FW+LBベストエフォートタイプに対応

### DIFF
--- a/protocol/FwLbBestEffortAdd.go
+++ b/protocol/FwLbBestEffortAdd.go
@@ -1,0 +1,91 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortAdd FW+LBベストエフォートタイプ追加申込 (非同期)
+//  http://manual.iij.jp/p2/pubapi/161905456.html
+type FwLbBestEffortAdd struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	Type           string // FW+LB ベストエフォートタイプ品目
+}
+
+// URI /{{.GisServiceCode}}/best-effort-fw-lbs.json
+func (t FwLbBestEffortAdd) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs.json"
+}
+
+// APIName FwLbBestEffortAdd
+func (t FwLbBestEffortAdd) APIName() string {
+	return "FwLbBestEffortAdd"
+}
+
+// Method POST
+func (t FwLbBestEffortAdd) Method() string {
+	return "POST"
+}
+
+// Document http://manual.iij.jp/p2/pubapi/161905456.html
+func (t FwLbBestEffortAdd) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/161905456.html"
+}
+
+// JPName FW+LBベストエフォートタイプ追加申込
+func (t FwLbBestEffortAdd) JPName() string {
+	return "FW+LBベストエフォートタイプ追加申込"
+}
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortAdd{})
+	TypeMap["FwLbBestEffortAdd"] = reflect.TypeOf(FwLbBestEffortAdd{})
+}
+
+// FwLbBestEffortAddResponse FW+LBベストエフォートタイプ追加申込のレスポンス
+type FwLbBestEffortAddResponse struct {
+	*CommonResponse
+	ServiceCode    string // FW+LBベストエフォートタイプのサービスコード(ilb########)
+	Label          string // ラベル(文字列)
+	ContractStatus string // 契約状態
+	StartDate      string // 利用開始日(YYYYMMDD)
+	StopDate       string // 解約予定日(YYYYMMDD)
+	Type           string // FW+LBベストエフォートタイプ品目
+	Redundant      string // 冗長構成有無(Yes" "No)
+	ResourceStatus string // FW+LBベストエフォートタイプステータス
+	External       struct {
+		NetworkType string `json:",omitempty"` // ネットワーク種別
+	}
+	Internal struct {
+		NetworkType      string `json:",omitempty"` // ネットワーク種別
+		TrafficIpAddress string `json:",omitempty"` // トラフィックIPアドレス(IPアドレス)
+		ServiceCode      string `json:",omitempty"` // ネットワーク種別がPrivateの場合のみ、サービスコード(ivl########)
+	}
+	HostList []struct {
+		Master         string // マスターならばYes, スレーブならばNo(Yes" "No)
+		ResourceStatus string // FW+LBベストエフォートタイプステータス
+		External       struct {
+			IPv4Address string `json:",omitempty"` // IPv4アドレス
+		}
+		Internal struct {
+			IPv4Address string `json:",omitempty"` // IPv4アドレス
+		}
+	}
+	Lb struct {
+		TrafficIpList []struct {
+			IPv4 struct {
+				TrafficIpName    string // トラフィックIP名(文字列)
+				TrafficIpAddress string // トラフィックIPv4アドレス(IPv4アドレス)
+				DomainName       string `json:",omitempty"` // 逆引きドメイン名。ネットワーク種別がGlobalに限る(文字列)
+			} `json:",omitempty"`
+		}
+	}
+	SnatRuleList []struct {
+		SourceIpAddress   string // 変換元IPアドレス(IPv4アドレス)
+		ToSourceIpAddress string // 変換先IPアドレス(IPアドレス)
+	}
+	StaticRouteList []struct {
+		Destination   string // 設定した宛先ネットワークアドレス(IPv4アドレス/マスク長)
+		Gateway       string // 設定したゲートウェイアドレス(IPv4アドレス)
+		ServiceCode   string `json:",omitempty"` // 設定したインターフェイス(ivl########)
+		StaticRouteId string // スタティックルートID(数字)
+	}
+}

--- a/protocol/FwLbBestEffortCancel.go
+++ b/protocol/FwLbBestEffortCancel.go
@@ -1,0 +1,53 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortCancel FW+LBベストエフォートタイプ解約申込 (同期)
+//  http://manual.iij.jp/p2/pubapi/162302634.html
+type FwLbBestEffortCancel struct {
+	GisServiceCode string `json:"-"`                // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"`                // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	StopDate       string `json:"-" p2pub:",query"` // 解約予定日。省略の場合は即時(YYYYMMDD)
+}
+
+// URI /{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}.json
+func (t FwLbBestEffortCancel) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}.json"
+}
+
+// APIName FwLbBestEffortCancel
+func (t FwLbBestEffortCancel) APIName() string {
+	return "FwLbBestEffortCancel"
+}
+
+// Method DELETE
+func (t FwLbBestEffortCancel) Method() string {
+	return "DELETE"
+}
+
+// Document http://manual.iij.jp/p2/pubapi/162302634.html
+func (t FwLbBestEffortCancel) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162302634.html"
+}
+
+// JPName FW+LBベストエフォートタイプ解約申込
+func (t FwLbBestEffortCancel) JPName() string {
+	return "FW+LBベストエフォートタイプ解約申込"
+}
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortCancel{})
+	TypeMap["FwLbBestEffortCancel"] = reflect.TypeOf(FwLbBestEffortCancel{})
+}
+
+// FwLbBestEffortCancelResponse FW+LBベストエフォートタイプ解約申込のレスポンス
+type FwLbBestEffortCancelResponse struct {
+	*CommonResponse
+	Current struct {
+		StopDate string `json:",omitempty"` // 設定した解約予定日(YYYYMMDD)
+	} `json:",omitempty"`
+	Previous struct {
+		StopDate string `json:",omitempty"` // 設定前の解約予定日(YYYYMMDD)
+	} `json:",omitempty"`
+}

--- a/protocol/FwLbBestEffortConfigAdd.go
+++ b/protocol/FwLbBestEffortConfigAdd.go
@@ -1,0 +1,62 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortConfigAdd ロードバランシング設定追加
+//  http://manual.iij.jp/p2/pubapi/162312646.html
+type FwLbBestEffortConfigAdd struct {
+	GisServiceCode    string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode    string `json:"-"` // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	Name              string // 設定名
+	TrafficIpName     string // TrafficIp の名前
+	Port              string // ポート番号
+	Protocol          string // プロトコル
+	Algorithm         string // 負荷分散方式
+	IpTransparent     string // IPアドレス透過
+	HealthCheckMethod string // ヘルスチェック方式
+}
+
+// URI /:GisServiceCode/best-effort-fw-lbs/:IlbServiceCode/lb/configs.json
+func (t FwLbBestEffortConfigAdd) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/lb/configs.json"
+}
+
+// APIName FwLbBestEffortConfigAdd
+func (t FwLbBestEffortConfigAdd) APIName() string {
+	return "FwLbBestEffortConfigAdd"
+}
+
+// Method GET
+func (t FwLbBestEffortConfigAdd) Method() string {
+	return "POST"
+}
+
+// http://manual.iij.jp/p2/pubapi/162312646.html
+func (t FwLbBestEffortConfigAdd) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162312646.html"
+}
+
+// JPName ロードバランシング設定追加
+func (t FwLbBestEffortConfigAdd) JPName() string {
+	return "ロードバランシング設定追加"
+}
+
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortConfigAdd{})
+	TypeMap["FwLbBestEffortConfigAdd"] = reflect.TypeOf(FwLbBestEffortConfigAdd{})
+}
+
+// FwLbBestEffortConfigAddResponse ロードバランシング設定追加 のレスポンス
+type FwLbBestEffortConfigAddResponse struct {
+	*CommonResponse
+	Id                string // ロードバランシング設定のID
+	Name              string // 設定名
+	TrafficIpName     string // TrafficIp の名前
+	Port              string // ポート番号
+	Protocol          string // プロトコル
+	Algorithm         string // 負荷分散方式
+	IpTransparent     string // IPアドレス透過
+	HealthCheckMethod string // ヘルスチェック方式
+}

--- a/protocol/FwLbBestEffortConfigChange.go
+++ b/protocol/FwLbBestEffortConfigChange.go
@@ -1,0 +1,67 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortConfigChange ロードバランシング設定変更
+//  http://manual.iij.jp/p2/pubapi/162312792.html
+type FwLbBestEffortConfigChange struct {
+	GisServiceCode    string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode    string `json:"-"` // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	Id                string `json:"-"` // ロードバランシング設定のID
+	Name              string // 設定名
+	Protocol          string // プロトコル
+	Algorithm         string // 負荷分散方式
+	IpTransparent     string // IPアドレス透過
+	HealthCheckMethod string // ヘルスチェック方式
+}
+
+// URI /:GisServiceCode/best-effort-fw-lbs/:IlbServiceCode/lb/configs/Id.json
+func (t FwLbBestEffortConfigChange) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/lb/configs/{{.Id}}.json"
+}
+
+// APIName FwLbBestEffortConfigChange
+func (t FwLbBestEffortConfigChange) APIName() string {
+	return "FwLbBestEffortConfigChange"
+}
+
+// Method GET
+func (t FwLbBestEffortConfigChange) Method() string {
+	return "PUT"
+}
+
+// http://manual.iij.jp/p2/pubapi/162312792.html
+func (t FwLbBestEffortConfigChange) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162312792.html"
+}
+
+// JPName ロードバランシング設定変更
+func (t FwLbBestEffortConfigChange) JPName() string {
+	return "ロードバランシング設定変更"
+}
+
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortConfigChange{})
+	TypeMap["FwLbBestEffortConfigChange"] = reflect.TypeOf(FwLbBestEffortConfigChange{})
+}
+
+// FwLbBestEffortConfigChangeResponse ロードバランシング設定変更 のレスポンス
+type FwLbBestEffortConfigChangeResponse struct {
+	*CommonResponse
+	Current struct {
+		Name              string // 設定名
+		Protocol          string // プロトコル
+		Algorithm         string // 負荷分散方式
+		IpTransparent     string // IPアドレス透過
+		HealthCheckMethod string // ヘルスチェック方式
+	}
+	Previous struct {
+		Name              string // 設定名
+		Protocol          string // プロトコル
+		Algorithm         string // 負荷分散方式
+		IpTransparent     string // IPアドレス透過
+		HealthCheckMethod string // ヘルスチェック方式
+	}
+}

--- a/protocol/FwLbBestEffortConfigDelete.go
+++ b/protocol/FwLbBestEffortConfigDelete.go
@@ -1,0 +1,56 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortConfigDelete ロードバランシング設定削除
+//  http://manual.iij.jp/p2/pubapi/162312797.html
+type FwLbBestEffortConfigDelete struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"` // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	Id             string `json:"-"` // ロードバランシング設定のID
+}
+
+// URI /:GisServiceCode/best-effort-fw-lbs/:IlbServiceCode/lb/configs/:Id.json
+func (t FwLbBestEffortConfigDelete) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/lb/configs/{{.Id}}.json"
+}
+
+// APIName FwLbBestEffortConfigDelete
+func (t FwLbBestEffortConfigDelete) APIName() string {
+	return "FwLbBestEffortConfigDelete"
+}
+
+// Method GET
+func (t FwLbBestEffortConfigDelete) Method() string {
+	return "DELETE"
+}
+
+// http://manual.iij.jp/p2/pubapi/162312797.html
+func (t FwLbBestEffortConfigDelete) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162312797.html"
+}
+
+// JPName ロードバランシング設定削除
+func (t FwLbBestEffortConfigDelete) JPName() string {
+	return "ロードバランシング設定削除"
+}
+
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortConfigDelete{})
+	TypeMap["FwLbBestEffortConfigDelete"] = reflect.TypeOf(FwLbBestEffortConfigDelete{})
+}
+
+// FwLbBestEffortConfigDeleteResponse ロードバランシング設定削除 のレスポンス
+type FwLbBestEffortConfigDeleteResponse struct {
+	*CommonResponse
+	Id                string // ロードバランシング設定のID
+	Name              string // 設定名
+	TrafficIpName     string // TrafficIp の名前
+	Port              string // ポート番号
+	Protocol          string // プロトコル
+	Algorithm         string // 負荷分散方式
+	IpTransparent     string // IPアドレス透過
+	HealthCheckMethod string // ヘルスチェック方式
+}

--- a/protocol/FwLbBestEffortConfigGet.go
+++ b/protocol/FwLbBestEffortConfigGet.go
@@ -1,0 +1,55 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortConfigGet ロードバランシング設定情報取得
+//  http://manual.iij.jp/p2/pubapi/162312652.html
+type FwLbBestEffortConfigGet struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"` // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	Id             string `json:"-"` // ロードバランシング設定のID
+}
+
+// URI /:GisServiceCode/best-effort-fw-lbs/:IlbServiceCode/lb/configs/Id.json
+func (t FwLbBestEffortConfigGet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/lb/configs/{{.Id}}.json"
+}
+
+// APIName FwLbBestEffortConfigGet
+func (t FwLbBestEffortConfigGet) APIName() string {
+	return "FwLbBestEffortConfigGet"
+}
+
+// Method GET
+func (t FwLbBestEffortConfigGet) Method() string {
+	return "GET"
+}
+
+// http://manual.iij.jp/p2/pubapi/162312652.html
+func (t FwLbBestEffortConfigGet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162312652.html"
+}
+
+// JPName ロードバランシング設定情報取得
+func (t FwLbBestEffortConfigGet) JPName() string {
+	return "ロードバランシング設定情報取得"
+}
+
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortConfigGet{})
+	TypeMap["FwLbBestEffortConfigGet"] = reflect.TypeOf(FwLbBestEffortConfigGet{})
+}
+
+// FwLbBestEffortConfigGetResponse ロードバランシング設定情報取得 のレスポンス
+type FwLbBestEffortConfigGetResponse struct {
+	*CommonResponse
+	Name              string // 設定名
+	TrafficIpName     string // TrafficIp の名前
+	Port              string // ポート番号
+	Protocol          string // プロトコル
+	Algorithm         string // 負荷分散方式
+	IpTransparent     string // IPアドレス透過
+	HealthCheckMethod string // ヘルスチェック方式
+}

--- a/protocol/FwLbBestEffortConfigListGet.go
+++ b/protocol/FwLbBestEffortConfigListGet.go
@@ -1,0 +1,57 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortConfigListGet ロードバランシング設定情報一覧取得
+//  http://manual.iij.jp/p2/pubapi/162312601.html
+type FwLbBestEffortConfigListGet struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"` // FW+LBベストエフォートタイプのサービスコード
+}
+
+// URI /:GisServiceCode/best-effort-fw-lbs/:IlbServiceCode/lb/configs.json
+func (t FwLbBestEffortConfigListGet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/lb/configs.json"
+}
+
+// APIName FwLbBestEffortConfigListGet
+func (t FwLbBestEffortConfigListGet) APIName() string {
+	return "FwLbBestEffortConfigListGet"
+}
+
+// Method GET
+func (t FwLbBestEffortConfigListGet) Method() string {
+	return "GET"
+}
+
+// http://manual.iij.jp/p2/pubapi/162312601.html
+func (t FwLbBestEffortConfigListGet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162312601.html"
+}
+
+// JPName ロードバランシング設定情報一覧取得
+func (t FwLbBestEffortConfigListGet) JPName() string {
+	return "ロードバランシング設定情報一覧取得"
+}
+
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortConfigListGet{})
+	TypeMap["FwLbBestEffortConfigListGet"] = reflect.TypeOf(FwLbBestEffortConfigListGet{})
+}
+
+// FwLbBestEffortConfigListGetResponse ロードバランシング設定情報一覧取得 のレスポンス
+type FwLbBestEffortConfigListGetResponse struct {
+	*CommonResponse
+	LbConfigList []struct {
+		Id                string // ロードバランシング設定を一意に識別するID
+		Name              string // 設定名
+		TrafficIpName     string // TrafficIp の名前
+		Port              string // ポート番号
+		Protocol          string // プロトコル
+		Algorithm         string // 負荷分散方式
+		IpTransparent     string // IPアドレス透過
+		HealthCheckMethod string // ヘルスチェック方式
+	}
+}

--- a/protocol/FwLbBestEffortContractGet.go
+++ b/protocol/FwLbBestEffortContractGet.go
@@ -1,0 +1,48 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortContractGet FW+LBベストエフォートタイプ契約状態取得 (同期)
+//  http://manual.iij.jp/p2/pubapi/59940915.html
+type FwLbBestEffortContractGet struct {
+	GisServiceCode string `json:"-"`                // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"`                // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	Item           string `json:"-" p2pub:",query"` // 取得するフィールド("ContractStatus")
+}
+
+// URI /{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}.json
+func (t FwLbBestEffortContractGet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}.json"
+}
+
+// APIName FwLbBestEffortContractGet
+func (t FwLbBestEffortContractGet) APIName() string {
+	return "FwLbBestEffortContractGet"
+}
+
+// Method GET
+func (t FwLbBestEffortContractGet) Method() string {
+	return "GET"
+}
+
+// Document http://manual.iij.jp/p2/pubapi/59940915.html
+func (t FwLbBestEffortContractGet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/59940915.html"
+}
+
+// JPName FW+LBベストエフォートタイプ契約状態取得
+func (t FwLbBestEffortContractGet) JPName() string {
+	return "FW+LBベストエフォートタイプ契約状態取得"
+}
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortContractGet{})
+	TypeMap["FwLbBestEffortContractGet"] = reflect.TypeOf(FwLbBestEffortContractGet{})
+}
+
+// FwLbBestEffortContractGetResponse FW+LBベストエフォートタイプ契約状態取得のレスポンス
+type FwLbBestEffortContractGetResponse struct {
+	*CommonResponse
+	ContractStatus string `json:",omitempty"` // 契約状態
+}

--- a/protocol/FwLbBestEffortContractListGet.go
+++ b/protocol/FwLbBestEffortContractListGet.go
@@ -1,0 +1,52 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortContractListGet FW+LBベストエフォートタイプ契約状態一覧取得 (同期)
+//  http://manual.iij.jp/p2/pubapi/162300148.html
+type FwLbBestEffortContractListGet struct {
+	GisServiceCode string `json:"-"`                // P2契約のサービスコード(gis########)
+	Item           string `json:"-" p2pub:",query"` // 取得するフィールド("ContractStatus")
+	StartIndex     string `json:"-" p2pub:",query"` // StartIndexだけスキップした位置から情報を取得する(数値)
+	Count          string `json:"-" p2pub:",query"` // 取得する情報の最大数(数値)
+}
+
+// URI /{{.GisServiceCode}}/best-effort-fw-lbs.json
+func (t FwLbBestEffortContractListGet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs.json"
+}
+
+// APIName FwLbBestEffortContractListGet
+func (t FwLbBestEffortContractListGet) APIName() string {
+	return "FwLbBestEffortContractListGet"
+}
+
+// Method GET
+func (t FwLbBestEffortContractListGet) Method() string {
+	return "GET"
+}
+
+// Document http://manual.iij.jp/p2/pubapi/59940887.html
+func (t FwLbBestEffortContractListGet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/59940887.html"
+}
+
+// JPName FW+LBベストエフォートタイプ契約状態一覧取得
+func (t FwLbBestEffortContractListGet) JPName() string {
+	return "FW+LBベストエフォートタイプ契約状態一覧取得"
+}
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortContractListGet{})
+	TypeMap["FwLbBestEffortContractListGet"] = reflect.TypeOf(FwLbBestEffortContractListGet{})
+}
+
+// FwLbBestEffortContractListGetResponse FW+LBベストエフォートタイプ契約状態一覧取得のレスポンス
+type FwLbBestEffortContractListGetResponse struct {
+	*CommonResponse
+	BestEffortFwLbList []struct {
+		ContractStatus string `json:",omitempty"` // 契約状態
+		ServiceCode    string `json:",omitempty"` // FW+LBのサービスコード(ilb########)
+	} `json:",omitempty"`
+}

--- a/protocol/FwLbBestEffortDestinationAdd.go
+++ b/protocol/FwLbBestEffortDestinationAdd.go
@@ -1,0 +1,61 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortDestinationAdd ロードバランス先追加
+//  http://manual.iij.jp/p2/pubapi/162315113.html
+type FwLbBestEffortDestinationAdd struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"` // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	LbConfigId     string // ロードバランシング設定のID
+	IpAddress      string // ロードバランス先アドレス
+	Port           string // ロードバランス先ポート番号
+	Weight         string `json:",omitempty"` // ロードバランス先重み
+	Failover       string // フェールオーバー先
+	Enabled        string // 有効・無効
+}
+
+// URI /:GisServiceCode/best-effort-fw-lbs/:IlbServiceCode/lb/destinations.json
+func (t FwLbBestEffortDestinationAdd) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/lb/destinations.json"
+}
+
+// APIName FwLbBestEffortDestinationAdd
+func (t FwLbBestEffortDestinationAdd) APIName() string {
+	return "FwLbBestEffortDestinationAdd"
+}
+
+// Method POST
+func (t FwLbBestEffortDestinationAdd) Method() string {
+	return "POST"
+}
+
+// http://manual.iij.jp/p2/pubapi/162315113.html
+func (t FwLbBestEffortDestinationAdd) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162315113.html"
+}
+
+// JPName ロードバランス先追加
+func (t FwLbBestEffortDestinationAdd) JPName() string {
+	return "ロードバランス先追加"
+}
+
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortDestinationAdd{})
+	TypeMap["FwLbBestEffortDestinationAdd"] = reflect.TypeOf(FwLbBestEffortDestinationAdd{})
+}
+
+// FwLbBestEffortDestinationAddResponse ロードバランス先追加 のレスポンス
+type FwLbBestEffortDestinationAddResponse struct {
+	*CommonResponse
+	Id                string // ロードバランス先を一意に識別するID
+	LbConfigId        string // ロードバランシング設定のID
+	IpAddress         string // ロードバランス先アドレス
+	Port              string // ロードバランス先ポート番号
+	Weight            string // ロードバランス先重み
+	Failover          string // フェールオーバー先
+	Enabled           string // 有効・無効
+	HealthCheckStatus string // ヘルスチェックステータス
+}

--- a/protocol/FwLbBestEffortDestinationChange.go
+++ b/protocol/FwLbBestEffortDestinationChange.go
@@ -1,0 +1,58 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortDestinationChange ロードバランス先設定変更
+//  http://manual.iij.jp/p2/pubapi/162315127.html
+type FwLbBestEffortDestinationChange struct {
+	GisServiceCode string `json:"-"`          // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"`          // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	Id             string `json:"-"`          // ロードバランス先を一意に識別するID
+	Weight         string `json:",omitempty"` // ロードバランス先重み
+	Enabled        string // 有効・無効
+}
+
+// URI /:GisServiceCode/best-effort-fw-lbs/:IlbServiceCode/lb/destinations/:Id.json
+func (t FwLbBestEffortDestinationChange) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/lb/destinations/{{.Id}}.json"
+}
+
+// APIName FwLbBestEffortDestinationChange
+func (t FwLbBestEffortDestinationChange) APIName() string {
+	return "FwLbBestEffortDestinationChange"
+}
+
+// Method PUT
+func (t FwLbBestEffortDestinationChange) Method() string {
+	return "PUT"
+}
+
+// http://manual.iij.jp/p2/pubapi/162315127.html
+func (t FwLbBestEffortDestinationChange) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162315127.html"
+}
+
+// JPName ロードバランス先設定変更
+func (t FwLbBestEffortDestinationChange) JPName() string {
+	return "ロードバランス先設定変更"
+}
+
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortDestinationChange{})
+	TypeMap["FwLbBestEffortDestinationChange"] = reflect.TypeOf(FwLbBestEffortDestinationChange{})
+}
+
+// FwLbBestEffortDestinationChangeResponse ロードバランス先設定変更 のレスポンス
+type FwLbBestEffortDestinationChangeResponse struct {
+	*CommonResponse
+	Current struct {
+		Weight  string // ロードバランス先重み
+		Enabled string // 有効・無効
+	}
+	Previous struct {
+		Weight  string // ロードバランス先重み
+		Enabled string // 有効・無効
+	}
+}

--- a/protocol/FwLbBestEffortDestinationDelete.go
+++ b/protocol/FwLbBestEffortDestinationDelete.go
@@ -1,0 +1,55 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortDestinationDelete ロードバランス先削除
+//  http://manual.iij.jp/p2/pubapi/162315135.html
+type FwLbBestEffortDestinationDelete struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"` // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	Id             string `json:"-"` // ロードバランス先を一意に識別するID
+}
+
+// URI /:GisServiceCode/best-effort-fw-lbs/:IlbServiceCode/lb/destinations/:Id.json
+func (t FwLbBestEffortDestinationDelete) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/lb/destinations/{{.Id}}.json"
+}
+
+// APIName FwLbBestEffortDestinationDelete
+func (t FwLbBestEffortDestinationDelete) APIName() string {
+	return "FwLbBestEffortDestinationDelete"
+}
+
+// Method DELETE
+func (t FwLbBestEffortDestinationDelete) Method() string {
+	return "DELETE"
+}
+
+// http://manual.iij.jp/p2/pubapi/162315135.html
+func (t FwLbBestEffortDestinationDelete) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162315135.html"
+}
+
+// JPName ロードバランス先削除
+func (t FwLbBestEffortDestinationDelete) JPName() string {
+	return "ロードバランス先削除"
+}
+
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortDestinationDelete{})
+	TypeMap["FwLbBestEffortDestinationDelete"] = reflect.TypeOf(FwLbBestEffortDestinationDelete{})
+}
+
+// FwLbBestEffortDestinationDeleteResponse ロードバランス先削除 のレスポンス
+type FwLbBestEffortDestinationDeleteResponse struct {
+	*CommonResponse
+	LbConfigId        string // ロードバランシング設定のID
+	IpAddress         string // ロードバランス先アドレス
+	Port              string // ロードバランス先ポート番号
+	Weight            string // ロードバランス先重み
+	Failover          string // フェールオーバー先
+	Enabled           string // 有効・無効
+	HealthCheckStatus string // ヘルスチェックステータス
+}

--- a/protocol/FwLbBestEffortDestinationGet.go
+++ b/protocol/FwLbBestEffortDestinationGet.go
@@ -1,0 +1,55 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortDestinationGet ロードバランス先情報取得
+//  http://manual.iij.jp/p2/pubapi/162315120.html
+type FwLbBestEffortDestinationGet struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"` // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	Id             string `json:"-"` // ロードバランス先を一意に識別するID
+}
+
+// URI /:GisServiceCode/best-effort-fw-lbs/:IlbServiceCode/lb/destinations/:Id.json
+func (t FwLbBestEffortDestinationGet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/lb/destinations/{{.Id}}.json"
+}
+
+// APIName FwLbBestEffortDestinationGet
+func (t FwLbBestEffortDestinationGet) APIName() string {
+	return "FwLbBestEffortDestinationGet"
+}
+
+// Method GET
+func (t FwLbBestEffortDestinationGet) Method() string {
+	return "GET"
+}
+
+// http://manual.iij.jp/p2/pubapi/162315120.html
+func (t FwLbBestEffortDestinationGet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162315120.html"
+}
+
+// JPName ロードバランス先情報取得
+func (t FwLbBestEffortDestinationGet) JPName() string {
+	return "ロードバランス先情報取得"
+}
+
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortDestinationGet{})
+	TypeMap["FwLbBestEffortDestinationGet"] = reflect.TypeOf(FwLbBestEffortDestinationGet{})
+}
+
+// FwLbBestEffortDestinationGetResponse ロードバランス先情報取得 のレスポンス
+type FwLbBestEffortDestinationGetResponse struct {
+	*CommonResponse
+	LbConfigId        string // ロードバランシング設定のID
+	IpAddress         string // ロードバランス先アドレス
+	Port              string // ロードバランス先ポート番号
+	Weight            string // ロードバランス先重み
+	Failover          string // フェールオーバー先
+	Enabled           string // 有効・無効
+	HealthCheckStatus string // ヘルスチェックステータス
+}

--- a/protocol/FwLbBestEffortDestinationListGet.go
+++ b/protocol/FwLbBestEffortDestinationListGet.go
@@ -1,0 +1,57 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortDestinationListGet ロードバランス先情報一覧取得
+//  http://manual.iij.jp/p2/pubapi/162315096.html
+type FwLbBestEffortDestinationListGet struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"` // FW+LBベストエフォートタイプのサービスコード
+}
+
+// URI /:GisServiceCode/best-effort-fw-lbs/:IlbServiceCode/lb/destinations.json
+func (t FwLbBestEffortDestinationListGet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/lb/destinations.json"
+}
+
+// APIName FwLbBestEffortDestinationListGet
+func (t FwLbBestEffortDestinationListGet) APIName() string {
+	return "FwLbBestEffortDestinationListGet"
+}
+
+// Method GET
+func (t FwLbBestEffortDestinationListGet) Method() string {
+	return "GET"
+}
+
+// http://manual.iij.jp/p2/pubapi/162315096.html
+func (t FwLbBestEffortDestinationListGet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162315096.html"
+}
+
+// JPName ロードバランス先情報一覧取得
+func (t FwLbBestEffortDestinationListGet) JPName() string {
+	return "ロードバランス先情報一覧取得"
+}
+
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortDestinationListGet{})
+	TypeMap["FwLbBestEffortDestinationListGet"] = reflect.TypeOf(FwLbBestEffortDestinationListGet{})
+}
+
+// FwLbBestEffortDestinationListGetResponse ロードバランス先情報一覧取得 のレスポンス
+type FwLbBestEffortDestinationListGetResponse struct {
+	*CommonResponse
+	DestinationList []struct {
+		Id                string // ロードバランス先ID
+		LbConfigId        string // ロードバランシング設定のID
+		IpAddress         string // ロードバランス先アドレス
+		Port              string // ロードバランス先ポート番号
+		Weight            string // ロードバランス先重み
+		Failover          string // フェールオーバー先
+		Enabled           string // 有効・無効
+		HealthCheckStatus string // ヘルスチェックステータス
+	}
+}

--- a/protocol/FwLbBestEffortFilterGet.go
+++ b/protocol/FwLbBestEffortFilterGet.go
@@ -1,0 +1,57 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortFilterGet フィルタリングルール情報取得（FW+LBベストエフォートタイプ） (同期)
+//  http://manual.iij.jp/p2/pubapi/162646975.html
+type FwLbBestEffortFilterGet struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"` // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	IpVersion      string `json:"-"` // IPv4ルール（v4）
+	Direction      string `json:"-"` // 入力方向（ExternalからInternalへ）のルールか出力方向のルールか（in, out）
+}
+
+// URI /:GisServiceCode/best-effort-fw-lbs/:IlbServiceCode/filters/:IpVersion/:Direction.json
+func (t FwLbBestEffortFilterGet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/filters/{{.IpVersion}}/{{.Direction}}.json"
+}
+
+// APIName FwLbBestEffortFilterGet
+func (t FwLbBestEffortFilterGet) APIName() string {
+	return "FwLbBestEffortFilterGet"
+}
+
+// Method GET
+func (t FwLbBestEffortFilterGet) Method() string {
+	return "GET"
+}
+
+// http://manual.iij.jp/p2/pubapi/162646975.html
+func (t FwLbBestEffortFilterGet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162646975.html"
+}
+
+// JPName フィルタリングルール情報取得（FW+LBベストエフォートタイプ）
+func (t FwLbBestEffortFilterGet) JPName() string {
+	return "フィルタリングルール情報取得（FW+LBベストエフォートタイプ）"
+}
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortFilterGet{})
+	TypeMap["FwLbBestEffortFilterGet"] = reflect.TypeOf(FwLbBestEffortFilterGet{})
+}
+
+// FwLbBestEffortFilterGetResponse フィルタリングルール情報取得（FW+LBベストエフォートタイプ）のレスポンス
+type FwLbBestEffortFilterGetResponse struct {
+	*CommonResponse
+	FilterRuleList []struct {
+		FilterId           string // フィルタID
+		SourceNetwork      string // ソースネットワーク
+		DestinationNetwork string // デスティネーションネットワーク
+		DestinationPort    string // デスティネーションポート番号
+		Protocol           string // プロトコル
+		Action             string // ルールにマッチしたパケットに対する処理
+		Label              string // ラベル
+	}
+}

--- a/protocol/FwLbBestEffortFilterSet.go
+++ b/protocol/FwLbBestEffortFilterSet.go
@@ -1,0 +1,71 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortFilterSet フィルタリングルール一括設定（FW+LBベストエフォートタイプ） (同期)
+//  http://manual.iij.jp/p2/pubapi/162646983.html
+type FwLbBestEffortFilterSet struct {
+	GisServiceCode string       `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode string       `json:"-"` // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	IpVersion      string       `json:"-"` // IPv4ルール（V4）
+	Direction      string       `json:"-"` // 入力方向（ExternalからInternalへ）のルールか出力方向のルールか（in, out）
+	FilterRuleList []FilterRule `json:",omitempty"`
+}
+
+// URI /:GisServiceCode/best-effort-fw-lbs/:IlbServiceCode/filters/:IpVersion/:Direction.json
+func (t FwLbBestEffortFilterSet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/filters/{{.IpVersion}}/{{.Direction}}.json"
+}
+
+// APIName FwLbBestEffortFilterSet
+func (t FwLbBestEffortFilterSet) APIName() string {
+	return "FwLbBestEffortFilterSet"
+}
+
+// Method GET
+func (t FwLbBestEffortFilterSet) Method() string {
+	return "PUT"
+}
+
+// http://manual.iij.jp/p2/pubapi/162646983.html
+func (t FwLbBestEffortFilterSet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162646983.html"
+}
+
+// JPName フィルタリングルール一括設定（FW+LBベストエフォートタイプ）
+func (t FwLbBestEffortFilterSet) JPName() string {
+	return "フィルタリングルール一括設定（FW+LBベストエフォートタイプ）"
+}
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortFilterSet{})
+	TypeMap["FwLbBestEffortFilterSet"] = reflect.TypeOf(FwLbBestEffortFilterSet{})
+}
+
+// FwLbBestEffortFilterSetResponse フィルタリングルール一括設定（FW+LBベストエフォートタイプ）のレスポンス
+type FwLbBestEffortFilterSetResponse struct {
+	*CommonResponse
+	Current struct {
+		FilterList []struct {
+			FilterId           string `json:",omitempty"`
+			SourceNetwork      string `json:",omitempty"`
+			DestinationNetwork string `json:",omitempty"`
+			DestinationPort    string `json:",omitempty"`
+			Protocol           string `json:",omitempty"`
+			Action             string `json:",omitempty"`
+			Label              string `json:",omitempty"`
+		} `json:",omitempty"`
+	}
+	Previous struct {
+		FilterList []struct {
+			FilterId           string `json:",omitempty"`
+			SourceNetwork      string `json:",omitempty"`
+			DestinationNetwork string `json:",omitempty"`
+			DestinationPort    string `json:",omitempty"`
+			Protocol           string `json:",omitempty"`
+			Action             string `json:",omitempty"`
+			Label              string `json:",omitempty"`
+		} `json:",omitempty"`
+	}
+}

--- a/protocol/FwLbBestEffortGet.go
+++ b/protocol/FwLbBestEffortGet.go
@@ -1,0 +1,90 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortGet FW+LBベストエフォートタイプ情報取得 (同期)
+//  http://manual.iij.jp/p2/pubapi/162300440.html
+type FwLbBestEffortGet struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"` // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+}
+
+// URI /{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}.json
+func (t FwLbBestEffortGet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}.json"
+}
+
+// APIName FwLbBestEffortGet
+func (t FwLbBestEffortGet) APIName() string {
+	return "FwLbBestEffortGet"
+}
+
+// Method GET
+func (t FwLbBestEffortGet) Method() string {
+	return "GET"
+}
+
+// Document http://manual.iij.jp/p2/pubapi/162300440.html
+func (t FwLbBestEffortGet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162300440.html"
+}
+
+// JPName FW+LBベストエフォートタイプ情報取得
+func (t FwLbBestEffortGet) JPName() string {
+	return "FW+LBベストエフォートタイプ情報取得"
+}
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortGet{})
+	TypeMap["FwLbBestEffortGet"] = reflect.TypeOf(FwLbBestEffortGet{})
+}
+
+// FwLbBestEffortGetResponse FW+LBベストエフォートタイプ情報取得のレスポンス
+type FwLbBestEffortGetResponse struct {
+	*CommonResponse
+	Label          string // ラベル(文字列)
+	ContractStatus string // 契約状態
+	StartDate      string // 利用開始日(YYYYMMDD)
+	StopDate       string // 解約予定日(YYYYMMDD)
+	Type           string // FW+LBベストエフォートタイプ品目
+	Redundant      string // 冗長構成有無(Yes" "No)
+	ResourceStatus string // FW+LBベストエフォートタイプステータス
+	External       struct {
+		NetworkType string `json:",omitempty"` // ネットワーク種別
+	}
+	Internal struct {
+		NetworkType      string `json:",omitempty"` // ネットワーク種別
+		TrafficIpAddress string `json:",omitempty"` // トラフィックIPアドレス(IPアドレス)
+		ServiceCode      string `json:",omitempty"` // ネットワーク種別がPrivateの場合のみ、サービスコード(ivl########)
+	}
+	HostList []struct {
+		Master         string // マスターならばYes, スレーブならばNo(Yes" "No)
+		ResourceStatus string // FW+LBベストエフォートタイプステータス
+		External       struct {
+			IPv4Address string `json:",omitempty"` // IPv4アドレス
+		}
+		Internal struct {
+			IPv4Address string `json:",omitempty"` // IPv4アドレス
+		}
+	}
+	Lb struct {
+		TrafficIpList []struct {
+			IPv4 struct {
+				TrafficIpName    string // トラフィックIP名(文字列)
+				TrafficIpAddress string // トラフィックIPv4アドレス(IPv4アドレス)
+				DomainName       string `json:",omitempty"` // 逆引きドメイン名。ネットワーク種別がGlobalに限る(文字列)
+			} `json:",omitempty"`
+		}
+	}
+	SnatRuleList []struct {
+		SourceIpAddress   string // 変換元IPアドレス(IPv4アドレス)
+		ToSourceIpAddress string // 変換先IPアドレス(IPアドレス)
+	}
+	StaticRouteList []struct {
+		Destination   string // 設定した宛先ネットワークアドレス(IPv4アドレス/マスク長)
+		Gateway       string // 設定したゲートウェイアドレス(IPv4アドレス)
+		ServiceCode   string `json:",omitempty"` // 設定したインターフェイス(ivl########)
+		StaticRouteId string // スタティックルートID(数字)
+	}
+}

--- a/protocol/FwLbBestEffortLabelSet.go
+++ b/protocol/FwLbBestEffortLabelSet.go
@@ -1,0 +1,53 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortLabelSet FW+LBベストエフォートタイプラベル設定 (同期)
+//  http://manual.iij.jp/p2/pubapi/162303320.html
+type FwLbBestEffortLabelSet struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"` // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+	Name           string // ラベル(文字列)
+}
+
+// URI /{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/label.json
+func (t FwLbBestEffortLabelSet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/label.json"
+}
+
+// APIName FwLbBestEffortLabelSet
+func (t FwLbBestEffortLabelSet) APIName() string {
+	return "FwLbBestEffortLabelSet"
+}
+
+// Method PUT
+func (t FwLbBestEffortLabelSet) Method() string {
+	return "PUT"
+}
+
+// Document http://manual.iij.jp/p2/pubapi/162303320.html
+func (t FwLbBestEffortLabelSet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162303320.html"
+}
+
+// JPName FW+LBベストエフォートタイプラベル設定
+func (t FwLbBestEffortLabelSet) JPName() string {
+	return "FW+LBベストエフォートタイプラベル設定"
+}
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortLabelSet{})
+	TypeMap["FwLbBestEffortLabelSet"] = reflect.TypeOf(FwLbBestEffortLabelSet{})
+}
+
+// FwLbBestEffortLabelSetResponse FW+LBベストエフォートタイプラベル設定のレスポンス
+type FwLbBestEffortLabelSetResponse struct {
+	*CommonResponse
+	Current struct {
+		Label string `json:",omitempty"` // 設定したラベル(文字列)
+	} `json:",omitempty"`
+	Previous struct {
+		Label string `json:",omitempty"` // 設定前のラベル(文字列)
+	} `json:",omitempty"`
+}

--- a/protocol/FwLbBestEffortListGet.go
+++ b/protocol/FwLbBestEffortListGet.go
@@ -1,0 +1,94 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortListGet FW+LBベストエフォートタイプ情報一覧取得 (同期)
+//  http://manual.iij.jp/p2/pubapi/161906402.html
+type FwLbBestEffortListGet struct {
+	GisServiceCode string `json:"-"`                // P2契約のサービスコード(gis########)
+	StartIndex     string `json:"-" p2pub:",query"` // StartIndexだけスキップした位置から情報を取得する(数値)
+	Count          string `json:"-" p2pub:",query"` // 取得する情報の最大数(数値)
+}
+
+// URI /{{.GisServiceCode}}/best-effort-fw-lbs.json
+func (t FwLbBestEffortListGet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs.json"
+}
+
+// APIName FwLbBestEffortListGet
+func (t FwLbBestEffortListGet) APIName() string {
+	return "FwLbBestEffortListGet"
+}
+
+// Method GET
+func (t FwLbBestEffortListGet) Method() string {
+	return "GET"
+}
+
+// Document http://manual.iij.jp/p2/pubapi/161906402.html
+func (t FwLbBestEffortListGet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/161906402.html"
+}
+
+// JPName FW+LBベストエフォートタイプ情報一覧取得
+func (t FwLbBestEffortListGet) JPName() string {
+	return "FW+LBベストエフォートタイプ情報一覧取得"
+}
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortListGet{})
+	TypeMap["FwLbBestEffortListGet"] = reflect.TypeOf(FwLbBestEffortListGet{})
+}
+
+// FwLbBestEffortListGetResponse FW+LBベストエフォートタイプ情報一覧取得のレスポンス
+type FwLbBestEffortListGetResponse struct {
+	*CommonResponse
+	BestEffortFwLbList []struct {
+		ServiceCode    string // FW+LB ベストエフォートタイプのサービスコード(ilb########)
+		Label          string // ラベル(文字列)
+		ContractStatus string // 契約状態
+		StartDate      string // 利用開始日(YYYYMMDD)
+		StopDate       string // 解約予定日(YYYYMMDD)
+		Type           string // FW+LBベストエフォートタイプ品目
+		Redundant      string // 冗長構成有無(Yes" "No)
+		ResourceStatus string // FW+LBベストエフォートタイプステータス
+		External       struct {
+			NetworkType string `json:",omitempty"` // ネットワーク種別
+		}
+		Internal struct {
+			NetworkType      string `json:",omitempty"` // ネットワーク種別
+			TrafficIpAddress string `json:",omitempty"` // トラフィックIPアドレス(IPアドレス)
+			ServiceCode      string `json:",omitempty"` // ネットワーク種別がPrivateの場合のみ、サービスコード(ivl########)
+		}
+		HostList []struct {
+			Master         string // マスターならばYes, スレーブならばNo(Yes" "No)
+			ResourceStatus string // FW+LBベストエフォートタイプステータス
+			External       struct {
+				IPv4Address string `json:",omitempty"` // IPv4アドレス
+			}
+			Internal struct {
+				IPv4Address string `json:",omitempty"` // IPv4アドレス
+			}
+		}
+		Lb struct {
+			TrafficIpList []struct {
+				IPv4 struct {
+					TrafficIpName    string // トラフィックIP名(文字列)
+					TrafficIpAddress string // トラフィックIPv4アドレス(IPv4アドレス)
+					DomainName       string `json:",omitempty"` // 逆引きドメイン名。ネットワーク種別がGlobalに限る(文字列)
+				} `json:",omitempty"`
+			}
+		}
+		SnatRuleList []struct {
+			SourceIpAddress   string // 変換元IPアドレス(IPv4アドレス)
+			ToSourceIpAddress string // 変換先IPアドレス(IPアドレス)
+		}
+		StaticRouteList []struct {
+			Destination   string // 設定した宛先ネットワークアドレス(IPv4アドレス/マスク長)
+			Gateway       string // 設定したゲートウェイアドレス(IPv4アドレス)
+			ServiceCode   string `json:",omitempty"` // 設定したインターフェイス(ivl########)
+			StaticRouteId string // スタティックルートID(数字)
+		}
+	}
+}

--- a/protocol/FwLbBestEffortResourceGet.go
+++ b/protocol/FwLbBestEffortResourceGet.go
@@ -1,0 +1,52 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortResourceGet FW+LBベストエフォートタイプリソース状態取得 (同期)
+//  http://manual.iij.jp/p2/pubapi/162303028.html
+type FwLbBestEffortResourceGet struct {
+	GisServiceCode string `json:"-"`                // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"`                // IlbServiceCode
+	Item           string `json:"-" p2pub:",query"` // 取得するフィールド("ResourceStatus")
+}
+
+// URI /{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}.json
+func (t FwLbBestEffortResourceGet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}.json"
+}
+
+// APIName FwLbBestEffortResourceGet
+func (t FwLbBestEffortResourceGet) APIName() string {
+	return "FwLbBestEffortResourceGet"
+}
+
+// Method GET
+func (t FwLbBestEffortResourceGet) Method() string {
+	return "GET"
+}
+
+// Document http://manual.iij.jp/p2/pubapi/162303028.html
+func (t FwLbBestEffortResourceGet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162303028.html"
+}
+
+// JPName FW+LBベストエフォートタイプリソース状態取得
+func (t FwLbBestEffortResourceGet) JPName() string {
+	return "FW+LBベストエフォートタイプリソース状態取得"
+}
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortResourceGet{})
+	TypeMap["FwLbBestEffortResourceGet"] = reflect.TypeOf(FwLbBestEffortResourceGet{})
+}
+
+// FwLbBestEffortResourceGetResponse FW+LBベストエフォートタイプリソース状態取得のレスポンス
+type FwLbBestEffortResourceGetResponse struct {
+	*CommonResponse
+	ResourceStatus string `json:",omitempty"` // FW+LB ベストエフォートタイプステータス
+	HostList       []struct {
+		Master         string `json:",omitempty"` // マスターならばYes, スレーブならばNo(Yes" "No)
+		ResourceStatus string `json:",omitempty"` // FW+LB ベストエフォートタイプステータス
+	} `json:",omitempty"`
+}

--- a/protocol/FwLbBestEffortResourceListGet.go
+++ b/protocol/FwLbBestEffortResourceListGet.go
@@ -1,0 +1,56 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortResourceListGet FW+LBベストエフォートタイプリソース状態一覧取得 (同期)
+//  http://manual.iij.jp/p2/pubapi/162303028.html
+type FwLbBestEffortResourceListGet struct {
+	GisServiceCode string `json:"-"`                // P2契約のサービスコード(gis########)
+	Item           string `json:"-" p2pub:",query"` // 取得するフィールド("ResourceStatus")
+	StartIndex     string `json:"-" p2pub:",query"` // StartIndexだけスキップした位置から情報を取得する(数値)
+	Count          string `json:"-" p2pub:",query"` // 取得する情報の最大数(数値)
+}
+
+// URI /{{.GisServiceCode}}/best-effort-fw-lbs.json
+func (t FwLbBestEffortResourceListGet) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs.json"
+}
+
+// APIName FwLbBestEffortResourceListGet
+func (t FwLbBestEffortResourceListGet) APIName() string {
+	return "FwLbBestEffortResourceListGet"
+}
+
+// Method GET
+func (t FwLbBestEffortResourceListGet) Method() string {
+	return "GET"
+}
+
+// Document http://manual.iij.jp/p2/pubapi/162303028.html
+func (t FwLbBestEffortResourceListGet) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162303028.html"
+}
+
+// JPName FW+LBベストエフォートタイプリソース状態一覧取得
+func (t FwLbBestEffortResourceListGet) JPName() string {
+	return "FW+LBベストエフォートタイプリソース状態一覧取得"
+}
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortResourceListGet{})
+	TypeMap["FwLbBestEffortResourceListGet"] = reflect.TypeOf(FwLbBestEffortResourceListGet{})
+}
+
+// FwLbBestEffortResourceListGetResponse FW+LBベストエフォートタイプリソース状態一覧取得のレスポンス
+type FwLbBestEffortResourceListGetResponse struct {
+	*CommonResponse
+	BestEffortFwLbList []struct {
+		ResourceStatus string `json:",omitempty"` // FW+LB ベストエフォートタイプステータス
+		HostList       []struct {
+			Master         string `json:",omitempty"` // マスターならばYes, スレーブならばNo(Yes" "No)
+			ResourceStatus string `json:",omitempty"` // FW+LB ベストエフォートタイプステータス
+		} `json:",omitempty"`
+		ServiceCode string `json:",omitempty"` // FW+LB ベストエフォートタイプのサービスコード(ifl########)
+	} `json:",omitempty"`
+}

--- a/protocol/FwLbBestEffortSetup.go
+++ b/protocol/FwLbBestEffortSetup.go
@@ -1,0 +1,74 @@
+package protocol
+
+import (
+	"reflect"
+)
+
+// FwLbBestEffortSetup FW+LBベストエフォートタイプセットアップ (非同期)
+//  http://manual.iij.jp/p2/pubapi/162303464.html
+type FwLbBestEffortSetup struct {
+	GisServiceCode string `json:"-"` // P2契約のサービスコード(gis########)
+	IlbServiceCode string `json:"-"` // FW+LB ベストエフォートタイプのサービスコード(ifl########)
+	External       struct {
+		NetworkType   string // ネットワーク種別
+		TrafficIpName string // トラフィックIP名(文字列)
+	} `json:",omitempty"`
+	Internal struct {
+		ServiceCode       string `json:",omitempty"` // プライベートネットワーク/Vのサービスコード(ivl########)
+		TrafficIpAddress  string `json:",omitempty"` // トラフィックIPアドレス(IPv4アドレス)
+		Netmask           string `json:",omitempty"` // ネットマスク(数字)
+		NetworkType       string // ネットワーク種別
+		MasterHostAddress string `json:",omitempty"` // マスターのホストアドレス(IPv4アドレス)
+		TrafficIpName     string `json:",omitempty"` // トラフィックIP名(文字列)
+		SlaveHostAddress  string `json:",omitempty"` // スレーブのホストアドレス(IPv4アドレス)
+	} `json:",omitempty"`
+	ActionType string // "Setup"(リテラル)
+}
+
+// URI /{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/action.json
+func (t FwLbBestEffortSetup) URI() string {
+	return "/{{.GisServiceCode}}/best-effort-fw-lbs/{{.IlbServiceCode}}/action.json"
+}
+
+// APIName FwLbBestEffortSetup
+func (t FwLbBestEffortSetup) APIName() string {
+	return "FwLbBestEffortSetup"
+}
+
+// Method PUT
+func (t FwLbBestEffortSetup) Method() string {
+	return "PUT"
+}
+
+// Document http://manual.iij.jp/p2/pubapi/162303464.html
+func (t FwLbBestEffortSetup) Document() string {
+	return "http://manual.iij.jp/p2/pubapi/162303464.html"
+}
+
+// JPName FW+LBベストエフォートタイプセットアップ
+func (t FwLbBestEffortSetup) JPName() string {
+	return "FW+LBベストエフォートタイプセットアップ"
+}
+func init() {
+	APIlist = append(APIlist, FwLbBestEffortSetup{})
+	TypeMap["FwLbBestEffortSetup"] = reflect.TypeOf(FwLbBestEffortSetup{})
+}
+
+// FwLbBestEffortSetupResponse FW+LBベストエフォートタイプセットアップのレスポンス
+type FwLbBestEffortSetupResponse struct {
+	*CommonResponse
+	Current struct {
+		ResourceStatus string `json:",omitempty"` // FW+LB ベストエフォートタイプステータス
+		HostList       []struct {
+			Master         string `json:",omitempty"` // マスターならばYes, スレーブならばNo(Yes" "No)
+			ResourceStatus string `json:",omitempty"` // FW+LB ベストエフォートタイプステータス
+		} `json:",omitempty"`
+	} `json:",omitempty"`
+	Previous struct {
+		ResourceStatus string `json:",omitempty"` // FW+LB ベストエフォートタイプステータス
+		HostList       []struct {
+			Master         string `json:",omitempty"` // マスターならばYes, スレーブならばNo(Yes" "No)
+			ResourceStatus string `json:",omitempty"` // FW+LB ベストエフォートタイプステータス
+		} `json:",omitempty"`
+	} `json:",omitempty"`
+}


### PR DESCRIPTION

田口です。

FW+LBベストエフォートタイプ用APIがリリースされたので、こちらでも対応させました。このライブラリを利用してkubernetes用にcloud controller managerを実装し、これをもって動作確認としています。

なお、トラフィックIP関連、SNAT関連、スタティックルート関連は未実装です。
