### PR TITLE
リクエスト失敗時の戻り値が 0 になっている

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -364,6 +364,8 @@ func main() {
 	if len(os.Args) == 1 {
 		cmdrepl.CmdRepl("[P2PUB]# ", app)
 	} else {
-		app.Run(os.Args)
+		if err := app.Run(os.Args); err != nil {
+			os.Exit(-1)
+		}
 	}
 }


### PR DESCRIPTION
@tshibata-iij wrote:

リクエスト失敗時の戻り値が 0 になっている
```
$ ./p2pub P2PUBContractGet
ERRO[0000] missing arguments: [GisServiceCode]          
$ echo $?
0
```