### PR TITLE
Encryption param should be handling as required

### DIFF
--- a/protocol/StorageAdd.go
+++ b/protocol/StorageAdd.go
@@ -8,7 +8,7 @@ import (
 //  http://manual.iij.jp/p2/pubapi/59940088.html
 type StorageAdd struct {
 	GisServiceCode string `json:"-"`          // P2契約のサービスコード(gis########)
-	Encryption     string `json:",omitempty"` // 暗号化 ("Yes", "No")
+	Encryption     string // 暗号化 ("Yes", "No")
 	StorageGroup   string `json:",omitempty"` // ストレージグループ(Z/Y)
 	Type           string // 追加ストレージ品目
 }

--- a/protocol/SystemStorageAdd.go
+++ b/protocol/SystemStorageAdd.go
@@ -8,7 +8,7 @@ import (
 //  http://manual.iij.jp/p2/pubapi/59939812.html
 type SystemStorageAdd struct {
 	GisServiceCode    string `json:"-"`          // P2契約のサービスコード(gis########)
-	Encryption        string `json:",omitempty"` // 暗号化 ("Yes", "No")
+	Encryption        string // 暗号化 ("Yes", "No")
 	StorageGroup      string `json:",omitempty"` // ストレージグループ。省略時はどちらかのグループへ自動的に割り当てられます(Z/Y)
 	Type              string // ストレージ品目
 	ImageId           string `json:",omitempty"` // 利用するイメージのイメージID


### PR DESCRIPTION
`Encryption` parameter is an optional parameter for adding storage APIs.
But Type-X storage requires it.

Since P2 PUB has been stopped the order of Type-S storage, we can add Type-X series only.
From now its parameter could be considered as required.

タイプSストレージが購入できなくなり、タイプXストレージのみ購入可能となりました。
ストレージ追加APIでは`Encryption`パラメータがタイプXの場合のみ必須となっており、APIとしてはオプション扱いでしたが実質的に必須パラメータとなりましたので必須扱いとしてはどうでしょうか？