### PR TITLE
fix logrus import path

### DIFF
--- a/api.go
+++ b/api.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,7 +13,7 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/mattn/go-shellwords"
 
 	"github.com/iij/p2pubapi"

--- a/example/ls.go
+++ b/example/ls.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/urfave/cli"
 

--- a/example/pubkey.go
+++ b/example/pubkey.go
@@ -13,7 +13,7 @@ import (
 	"github.com/iij/p2pubapi"
 	"github.com/iij/p2pubapi/protocol"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 

--- a/parse.go
+++ b/parse.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"text/template"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/iij/p2pubapi/protocol"
 )


### PR DESCRIPTION
logrus の import path の大文字・小文字問題の修正です